### PR TITLE
add Level Versions

### DIFF
--- a/client/vue/components/DownloadButton.vue
+++ b/client/vue/components/DownloadButton.vue
@@ -1,9 +1,9 @@
 <template>
 	<div style="position: relative; border-radius: 5px; overflow: hidden;" class="notSelectable">
-		<button-with-icon icon="/assets/svg/download_black_24dp.svg" @click="download('platinumquest')" style="border-radius: 0px;"><slot></slot></button-with-icon>
+		<button-with-icon icon="/assets/svg/download_black_24dp.svg" @click="download('platinumquest', version)" style="border-radius: 0px;"><slot></slot></button-with-icon>
 		<img src="/assets/svg/expand_more_black_24dp.svg" class="expandMore basicIcon" :style="{ transform: chevronTransform }" @click="expanded = !expanded">
 		<div v-if="expanded">
-			<p v-for="assumption of assuming" :key="assumption.name" @click="download(assumption.name)" v-html="assumption.label"></p>
+			<p v-for="assumption of assuming" :key="assumption.name" @click="download(assumption.name, version)" v-html="assumption.label"></p>
 		</div>
 	</div>
 </template>
@@ -15,7 +15,8 @@ import ButtonWithIcon from './ButtonWithIcon.vue';
 export default defineComponent({
 	props: {
 		mode: String as PropType<'level' | 'pack' | 'multipleLevels'>,
-		id: Number as PropType<number>
+		id: Number as PropType<number>,
+		version: Number as PropType<number>
 	},
 	data() {
 		return {
@@ -38,12 +39,14 @@ export default defineComponent({
 		}
 	},
 	methods: {
-		/** Start downloading the .zip with the correct assumption parameter */
-		download(assumption: string) {
-			if (this.mode !== 'multipleLevels') window.location.href = window.location.origin + 
-				((this.mode === 'level')? `/api/level/${this.id}/zip?assuming=${assumption}`
-				: `/api/pack/${this.id}/zip?assuming=${assumption}`);
-
+		/** Start downloading the .zip with the correct assumption parameter and version */
+		download(assumption: string, version?: number) {
+			if (this.mode !== 'multipleLevels') {
+				let url = ((this.mode === 'level') ? `/api/level/${this.id}/zip?assuming=${assumption}` : `/api/pack/${this.id}/zip?assuming=${assumption}`);
+				if(version !== undefined)
+					url += `&version=${version}`;
+				window.location.href = window.location.origin + url;
+			}
 			this.$emit('download', assumption);
 		}
 	},

--- a/client/vue/pages/HomePage.vue
+++ b/client/vue/pages/HomePage.vue
@@ -32,7 +32,7 @@
 	</ul>
 	<div class="footer-container">
 		<div class="version" @click="showVersionHistory">
-			Marbleland v1.11.0
+			Marbleland v1.12.0
 		</div>
 		<router-link to="/support" class="support-button">Support</router-link>
 	</div>

--- a/client/vue/pages/LevelPage.vue
+++ b/client/vue/pages/LevelPage.vue
@@ -112,7 +112,7 @@
 					<span class="date">— {{ formatDate(ver.versionAddedAt) }}</span>
 					<strong v-if="ver.isCurrent" class="current-badge">(current)</strong>
 				</div>
-				<download-button v-if="!ver.isCurrent" :id="levelInfo.id" :version="ver.versionNumber" mode="level" class="small-download"></download-button>
+					<download-button v-if="!ver.isCurrent" :id="levelInfo.id" :version="ver.versionNumber" mode="level" class="small-download"></download-button>
 				</div>
 				<p class="changelog-text">{{ ver.changelog }}</p>
 			</div>
@@ -311,6 +311,8 @@ export default defineComponent({
 			this.notFound = true;
 			return;
 		}
+
+		console.log(doc);
 		
 		let mission = Mission.fromDoc(doc);
 		this.levelInfo = await mission.createExtendedLevelInfo(this.$store.state.loggedInAccount?.id);
@@ -1035,7 +1037,7 @@ h3 {
 .version-header {
 	display: flex;
 	justify-content: space-between;
-	align-items: center;
+	align-items: baseline;
 }
 
 .version-meta {

--- a/client/vue/pages/LevelPage.vue
+++ b/client/vue/pages/LevelPage.vue
@@ -31,7 +31,7 @@
 					<span v-if="levelInfo.hasCustomCode" style="color: orange"><br>Has custom code</span>
 				</p>
 				<div v-if="isCurator" class="curationPanel">
-					<h3>Curator score</h3>
+					<h3 @click="$refs.curatorDetailsModal.show();" class="curatorScore">Curator score</h3>
 
 					<div class="voteContainer">
 						<button-with-icon icon="/assets/svg/expand_more_black_24dp.svg" noMargin class="voteBtn up" :class="{ active: levelInfo.yourVote === true, disabled: isOwnLevel }" @click="submitVote(true)" title="This level demonstrates creative effort."></button-with-icon>
@@ -49,7 +49,7 @@
 				<div class="actions">
 					<img v-if="levelInfo.leaderboardInfo.length > 0" :src="showLBs ? '/assets/svg/info_24dp_FILL0_wght400_GRAD0_opsz24 (1).svg' : '/assets/svg/bar_chart_24dp.svg'" :title="showLBs ? 'Show level info' : 'Show leaderboards'" @click="toggleLBs" class="basicIcon">
 					<img src="/assets/svg/delete_black_24dp.svg" title="Delete level" v-if="hasOwnershipPermissions" @click="showDeleteConfirmation" class="basicIcon">
-					<!--<img src="/assets/svg/file_upload_black_24dp.svg" title="Update level" v-if="hasOwnershipPermissions" @click="deleteLevel" class="basicIcon">-->
+					<img src="/assets/svg/file_upload_black_24dp.svg" title="Update level" v-if="hasOwnershipPermissions" @click="updateLevel" class="basicIcon">
 					<img src="/assets/svg/edit_black_24dp.svg" title="Edit level" v-if="hasOwnershipPermissions" :class="{ disabled: editing }" @click="editing = true" class="basicIcon">
 					<img src="/assets/svg/create_new_folder_black_24dp.svg" title="Add to pack" v-if="$store.state.loggedInAccount && !$store.state.loggedInAccount.isSuspended" @click="$refs.packAdder.show()" class="basicIcon">
 					<pack-adder :levelId="levelInfo.id" class="packAdder" ref="packAdder"></pack-adder>
@@ -103,7 +103,20 @@
 		<div>
 			<comment-element v-for="comment of levelInfo.comments" :key="comment.id" :commentInfo="comment" @delete="deleteComment(comment.id)"></comment-element>
 		</div>
-
+		<div v-if="levelInfo.pastVersions && levelInfo.pastVersions.length > 0" class="version-history" >
+			<h3>Version History</h3>
+			<div v-for="ver in allVersions" :key="ver.versionNumber" class="version-item">
+				<div class="version-header">
+				<div class="version-meta">
+					<strong>v{{ ver.versionNumber }}</strong>
+					<span class="date">— {{ formatDate(ver.versionAddedAt) }}</span>
+					<strong v-if="ver.isCurrent" class="current-badge">(current)</strong>
+				</div>
+				<download-button v-if="!ver.isCurrent" :id="levelInfo.id" :version="ver.versionNumber" mode="level" class="small-download"></download-button>
+				</div>
+				<p class="changelog-text">{{ ver.changelog }}</p>
+			</div>
+		</div>
 		<Modal ref="deleteConfirmationModal">
 			<h2 class="deleteModalHeading">CAUTION: You're about to delete "{{ levelInfo.name }}"</h2>
 			<hr />
@@ -123,7 +136,7 @@
 						<strong>Discard this level's statistics</strong>, including all <strong>{{ levelInfo.downloads }}</strong> downloads and <strong>{{ levelInfo.lovedCount }}</strong> loves
 					</li>
 				</ul>
-				<p v-if="false">Should you have a newer version of this level that you want to replace it with, use the update feature instead.</p>
+				<p>Should you have a newer version of this level that you want to replace it with, use the update feature instead.</p>
 
 				<div class="deleteModalCheckboxContainer">
 					<input type="checkbox" id="deleteModelAcknowledgement" class="basicCheckbox" v-model="acknowledgedDeletionConsequences"><label for="deleteModelAcknowledgement" class="notSelectable">
@@ -141,12 +154,30 @@
 				</ButtonWithIcon>
 			</div>
 		</Modal>
+		<Modal ref="curatorDetailsModal">
+			<h2 style="text-align: center; margin-bottom: 5px;">Curator Votes</h2>
+			<hr style="margin-bottom: 0px;"/>
+			<div class="voteDetailsList">
+				<div>
+					<h3 class="voteHeader up">Upvoted by:</h3>
+					<profile-banner v-for="curator in upvoters" :key="curator.id" :profileInfo="curator"style="margin-bottom: 10px"></profile-banner>
+				</div>
+				<div>
+					<h3 class="voteHeader down">Downvoted by:</h3>
+					<profile-banner v-for="curator in downvoters" :key="curator.id" :profileInfo="curator"style="margin-bottom: 10px"></profile-banner>
+				</div>
+			</div>
+			<hr />
+			<div style="display: flex; justify-content: flex-end;">
+				<ButtonWithIcon @click="$refs.curatorDetailsModal.hide()">Close</ButtonWithIcon>
+			</div>
+		</Modal>
 	</template>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { CommentInfo, ExtendedLevelInfo, ReducedLeaderboardDefinition, LeaderboardScore, Modification, PackInfo } from '../../../shared/types';
+import { CommentInfo, ExtendedLevelInfo, ReducedLeaderboardDefinition, LeaderboardScore, Modification, PackInfo, ProfileInfo } from '../../../shared/types';
 import DownloadButton from '../components/DownloadButton.vue';
 import PlayButton from '../components/PlayButton.vue';
 import ProfileBanner from '../components/ProfileBanner.vue';
@@ -349,6 +380,27 @@ export default defineComponent({
 			const acc = this.$store.state.loggedInAccount;
 			return !!acc && this.levelInfo.addedBy?.id === acc.id;
 		},
+		allVersions() {
+			const current = {
+				versionNumber: this.levelInfo.currentVersion,
+				changelog: this.levelInfo.currentVersionChangelog,
+				versionAddedAt: this.levelInfo.editedAt,
+				isCurrent: true
+			};
+
+			const past = (this.levelInfo.pastVersions || []).map(v => ({
+				...v,
+				isCurrent: false
+			}));
+
+			return [...past, current].reverse();
+		},
+		upvoters(): ProfileInfo[] {
+			return this.levelInfo.curatorVotes.filter(v => v.vote === true).map(v => v.profile);
+		},
+		downvoters(): ProfileInfo[] {
+			return this.levelInfo.curatorVotes.filter(v => v.vote === false).map(v => v.profile);
+		}
 	},
 	methods: {
 		/** Turns the modification value into a pretty string. */
@@ -422,6 +474,9 @@ export default defineComponent({
 		},
 		closeDeleteConfirmationModal() {
 			(this.$refs.deleteConfirmationModal as any).hide();
+		},
+		async updateLevel() {
+			this.$router.push({ name: 'Upload', query: { updateId: this.levelInfo.id } });
 		},
 		async deleteLevel() {
 			this.closeDeleteConfirmationModal();
@@ -935,6 +990,11 @@ h3 {
     color: #f44336;
 }
 
+.curatorScore:hover {
+	text-decoration: underline;
+	cursor: pointer;
+}
+
 .aboutCuratorScore {
 	font-size: 14px;
 	opacity: 0.5;
@@ -946,6 +1006,65 @@ h3 {
 	opacity: 1.0;
 	text-decoration: underline;
 }
+
+.voteHeader {
+    margin-top: 14px;
+    font-size: 14px;
+}
+
+.voteHeader.up { 
+	color: #4caf50;
+	margin-bottom: 10px;
+}
+.voteHeader.down { 
+	color: #f44336; 
+	margin-bottom: 10px;
+}
+
+.voteDetailsList {
+	display: grid; 
+	grid-template-columns: 1fr 1fr; 
+	gap: 20px;
+}
+
+.version-item {
+	padding: 12px 0;
+	border-bottom: 1px solid var(--background-2);
+}
+
+.version-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
+
+.version-meta {
+	font-size: 0.95rem;
+}
+
+.version-meta .date {
+	color: var(--background-2);
+	margin-left: 6px;
+}
+
+.changelog-text {
+	margin-top: 6px;
+	font-size: 0.9rem;
+	line-height: 1.4;
+	white-space: pre-line;
+}
+
+.small-download {
+	transform: scale(0.75);
+	transform-origin: right center;
+}
+
+.current-badge {
+	color: #2e7d32;
+	font-size: 0.8rem;
+	margin-left: 6px;
+}
+
 </style>
 
 <style>

--- a/client/vue/pages/ProfilePage.vue
+++ b/client/vue/pages/ProfilePage.vue
@@ -57,6 +57,8 @@
 			<panel-list mode="level" :entries="profileInfo.uploadedLevels" :defaultCount="4" noEntriesNotice="This user has yet to upload any levels."></panel-list>
 			<h3>Created packs ({{ profileInfo.createdPacks.length }})</h3>
 			<panel-list mode="pack" :entries="profileInfo.createdPacks" :defaultCount="4" noEntriesNotice="This user has yet to create any packs."></panel-list>
+			<h3>Favorite levels ({{ profileInfo.favoriteLevels.length }})</h3>
+			<panel-list mode="level" :entries="profileInfo.favoriteLevels" :defaultCount="4" noEntriesNotice="This user has yet to love any levels. Cold!"></panel-list>
 		</template>
 		
 	</div>

--- a/client/vue/pages/UploadPage.vue
+++ b/client/vue/pages/UploadPage.vue
@@ -4,7 +4,8 @@
 		<meta name="og:title" content="Upload levels">
 	</Head>
 	<template v-if="$store.state.loggedInAccount && !$store.state.loggedInAccount.isSuspended">
-		<h1>Upload levels</h1>
+		<h1 v-if="!updateId">Upload levels</h1>
+		<h1 v-else>Update level</h1>
 		<p class="learnMore" @click="$router.push('/about-upload')">Learn more</p>
 		<p class="contentGuidelines" @click="$router.push('/content-guidelines')">Content guidelines</p>
 		<a href="/about-upload" @click.prevent=""></a> <!-- Let's hope Google will accept this xD -->
@@ -44,17 +45,25 @@
 				<img src="/assets/svg/chevron_left_black_24dp.svg" class="basicIcon" title="Cycle to previous level" v-if="successResponse.missions.length > 1" @click="currentIndex = (currentIndex - 1 + successResponse.missions.length) % successResponse.missions.length">
 				<img src="/assets/svg/chevron_right_black_24dp.svg" class="basicIcon" title="Cycle to next level" v-if="successResponse.missions.length > 1" @click="currentIndex = (currentIndex + 1) % successResponse.missions.length">
 			</div>
-			<h3>If you want to, add a few additional remarks describing this level ({{ successResponse.missions[currentIndex].name }}) and its creation before submitting it:</h3>
-			<textarea class="remarks basicTextarea" :placeholder="`Additional remarks on ${successResponse.missions[currentIndex].name}`" :maxlength="$store.state.levelRemarksMaxLength" v-model.trim="remarks[currentIndex]"></textarea>
+			<h3 v-if="updateId">
+				What's new in this version?
+			</h3>
+			<h3 v-else>
+				If you want to, add a few additional remarks describing this level ({{ successResponse.missions[currentIndex].name }}) and its creation before submitting it:
+			</h3>
+			<textarea class="remarks basicTextarea" :placeholder="(updateId ? 'Changes to' : 'Additional remarks on') + ' ' + successResponse.missions[currentIndex].name" :maxlength="$store.state.levelRemarksMaxLength" v-model.trim="remarks[currentIndex]"></textarea>
 
-			<hr>
+			<template v-if="!updateId">
+				<hr>
+				<h3>Optionally, choose the packs you want to add the uploaded {{ successResponse.missions.length > 1 ? 'levels' : 'level' }} to:</h3>
+				<panel-list mode="pack" :entries="successResponse.packs" :defaultCount="4" noEntriesNotice="" :selectedPacks="selectedPacks" v-if="successResponse.packs.length > 0"></panel-list>
 
-			<h3>Optionally, choose the packs you want to add the uploaded {{ successResponse.missions.length > 1 ? 'levels' : 'level' }} to:</h3>
-			<panel-list mode="pack" :entries="successResponse.packs" :defaultCount="4" noEntriesNotice="" :selectedPacks="selectedPacks" v-if="successResponse.packs.length > 0"></panel-list>
-
-			<input type="checkbox" id="createPackCheckbox" class="basicCheckbox" v-model="createNewPack"><label for="createPackCheckbox" class="notSelectable">Create new pack</label>
-			<input type="text" placeholder="Pack name" :maxlength="$store.state.packNameMaxLength" v-model.trim="newPackName" class="basicTextInput newPackName" v-if="createNewPack">
-			<textarea class="basicTextarea newPackDescription" placeholder="Pack description" :maxlength="$store.state.packDescriptionMaxLength" v-model.trim="newPackDescription" v-if="createNewPack"></textarea>
+				<input type="checkbox" id="createPackCheckbox" class="basicCheckbox" v-model="createNewPack">
+				<label for="createPackCheckbox" class="notSelectable">Create new pack</label>
+				
+				<input type="text" placeholder="Pack name" :maxlength="$store.state.packNameMaxLength" v-model.trim="newPackName" class="basicTextInput newPackName" v-if="createNewPack">
+				<textarea class="basicTextarea newPackDescription" placeholder="Pack description" :maxlength="$store.state.packDescriptionMaxLength" v-model.trim="newPackDescription" v-if="createNewPack"></textarea>
+			</template>
 
 			<hr>
 
@@ -104,7 +113,8 @@ export default defineComponent({
 			newPackName: "",
 			newPackDescription: "",
 			submitting: false,
-			dragEntered: false
+			dragEntered: false,
+			updateId: this.$route.query.updateId ? Number(this.$route.query.updateId) : null,
 		};
 	},
 	methods: {
@@ -144,7 +154,12 @@ export default defineComponent({
 			}
 
 			let request = new XMLHttpRequest(); // We use XMLHttpRequest here instead of fetch because it gives us access to upload progress data
-			request.open('POST', '/api/level/upload', true);
+
+			const endpoint = this.updateId 
+				? `/api/level/${this.updateId}/update-upload` 
+				: '/api/level/upload';
+
+			request.open('POST', endpoint, true);
 			request.setRequestHeader('Content-Type', 'application/zip');
 			request.withCredentials = true;
 			request.send(file);
@@ -214,8 +229,12 @@ export default defineComponent({
 
 			this.submitting = true;
 
+			const endpoint = this.updateId 
+				? `/api/level/${this.updateId}/update-submit` 
+				: `/api/level/submit`;
+
 			// Tell the server to submit the upload
-			let response = await fetch(`/api/level/submit`, {
+			let response = await fetch(endpoint, {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json'
@@ -223,7 +242,7 @@ export default defineComponent({
 				body: JSON.stringify({
 					uploadId: this.successResponse.uploadId,
 					remarks: this.remarks,
-					addToPacks: this.selectedPacks,
+					addToPacks: this.updateId ? [] : this.selectedPacks, // Don't change pack when updating level
 					newPack: this.createNewPack? {
 						name: this.newPackName,
 						description: this.newPackDescription

--- a/docs/api.md
+++ b/docs/api.md
@@ -50,6 +50,7 @@ Get the .zip archive for a given level.
 Name | Type | Meaning
 --- | --- | ---
 assuming | `'none' \| 'gold' \| 'platinumquest'` | *Defaults to `'platinumquest'`.* If present, specifies the set of default assets to exclude from the archive. For example, if set to `'gold'`, all MBG default assets won't be included with the .zip.
+version | `number` | If present, this version will be fetched if it exists.
 append-id-to-mis | `boolean` | If present, each level's ID will be appended to the end of its corresponding .mis file.
 
 ### `GET` /api/level/{level-id}/mbpak
@@ -60,6 +61,7 @@ Get the .mbpak archive for a given level.
 Name | Type | Meaning
 --- | --- | ---
 assuming | `'none' \| 'gold' \| 'platinumquest'` | *Defaults to `'platinumquest'`.* If present, specifies the set of default assets to exclude from the archive. For example, if set to `'gold'`, all MBG default assets won't be included with the .zip.
+version | `number` | If present, this version will be fetched if it exists.
 append-id-to-mis | `boolean` | If present, each level's ID will be appended to the end of its corresponding .mis file.
 
 ### `GET` /api/level/{level-id}/image
@@ -171,13 +173,11 @@ missionId* | `number` | The index of the mission whose image thumbnail should be
 }
 ```
 
-**Response body:**
-```typescript
-{
-	levelIds: number, // The IDs of the submitted levels
-	newPackId?: number // Should a new pack have been created, this will be the ID for that pack
-}
-```
+### `POST` /api/level/{level-id}/update-upload
+**Requires [authentication](#authentication).** Same as level uploading, but replaces the current level with the new one.
+
+### `POST` /api/level/{level-id}/update-submit
+**Requires [authentication](#authentication).** Same as level submit, but for level updates. The first remark becomes the version changelog.
 
 ### `PATCH` /api/level/{level-id}/edit
 **Requires [authentication](#authentication).** Edit the metadata of a previously submitted level. Right now, the level's MissionInfo and remarks can be edited.
@@ -603,6 +603,7 @@ Contains metadata about a level.
 	datablockCompatibility: 'mbg' | 'mbw' | 'pq', // Which variant of Marble Blast this level's datablocks are compatible with
 
 	curationScore: number, // Cumulative curator score
+	currentVersion: number;
 }
 ```
 
@@ -623,8 +624,29 @@ LevelInfo & {
 	playInfo: GameDefinition[], // Contains the definitions of the games the level can be played on
 	leaderboardInfo: ReducedLeaderboardDefinition[], // Contains the definitions of the leaderboards available for the level
 	// Visible to curators only:
-	curatorVotes: Record<number, boolean>, // All the votes cast by curators
+	curatorVotes: CuratorVoteInfo[], // All the votes cast by curators
 	yourVote: boolean, // Your curator vote; true for upvote, false for downvote
+	currentVersionChangelog: string, // Changes made in the latest version
+	pastVersions: VersionInfo[],
+}
+```
+
+### VersionInfo
+Contains minimal data about a level version.
+```typescript
+{
+	versionNumber: number;
+	versionAddedAt: number;
+	changelog: string;
+}
+```
+
+### CuratorVoteInfo
+Contains a curator vote (up or down) by a profile
+```typescript
+{
+    profile: ProfileInfo,
+    vote: boolean
 }
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -739,6 +739,7 @@ Contains metadata about a profile, as well as additional data to display on the 
 ProfileInfo & {
 	bio: string,
 	uploadedLevels: LevelInfo[], // Newest levels first
+	favoriteLevels: LevelInfo[], // Newest levels first
 	createdPacks: PackInfo[]
 }
 ```

--- a/server/ts/account.ts
+++ b/server/ts/account.ts
@@ -188,6 +188,16 @@ export const getExtendedProfileInfo = async (doc: AccountDoc): Promise<ExtendedP
 		uploadedLevels.push(mission.createLevelInfo());
 	}
 
+	// Add all of their favorites
+	let favoriteMissionDocs = await db.missions.find({ lovedBy: doc._id }) as MissionDoc[];
+	favoriteMissionDocs.sort((a, b) => b.addedAt - a.addedAt); // Show newest ones first
+	let favoriteLevels: LevelInfo[] = [];
+
+	for (let doc of favoriteMissionDocs) {
+		let mission = Mission.fromDoc(doc);
+		favoriteLevels.push(mission.createLevelInfo());
+	}
+
 	// Add all of their packs
 	let packDocs = await db.packs.find({ createdBy: doc._id }) as PackDoc[];
 	packDocs.sort((a, b) => b.createdAt - a.createdAt); // Show newest ones first
@@ -200,6 +210,7 @@ export const getExtendedProfileInfo = async (doc: AccountDoc): Promise<ExtendedP
 	return Object.assign(profileInfo, {
 		bio: doc.bio,
 		uploadedLevels,
+		favoriteLevels,
 		createdPacks
 	});
 };

--- a/server/ts/api/api_level.ts
+++ b/server/ts/api/api_level.ts
@@ -93,7 +93,8 @@ export const initLevelApi = () => {
 		if (levelId === null) return;
 
 		let doc = await db.missions.findOne({ _id: levelId }) as MissionDoc;
-		let mission = Mission.fromDoc(doc);
+		let version = req.query.version ? Number(req.query.version) : undefined;
+    	let mission = Mission.fromVersion(doc, version);
 
 		let assuming = req.query.assuming as string;
 		if (!['none', 'gold', 'platinumquest'].includes(assuming)) assuming = 'platinumquest'; // Default to PQ
@@ -103,7 +104,7 @@ export const initLevelApi = () => {
 		await incrementLevelDownloads(doc, req);
 
 		let fileName = Util.removeSpecialChars(doc.info.name.toLowerCase().split(' ').map(x => Util.uppercaseFirstLetter(x)).join(''));
-		stream.connectToResponse(res, `${fileName}-${doc._id}.zip`);
+		stream.connectToResponse(res, `${fileName}-${doc._id}${version !== undefined ? `-v${version}` : ""}.zip`);
 	});
 
 	// Get the .mbpak of a given level
@@ -112,7 +113,8 @@ export const initLevelApi = () => {
 		if (levelId === null) return;
 
 		let doc = await db.missions.findOne({ _id: levelId }) as MissionDoc;
-		let mission = Mission.fromDoc(doc);
+		let version = req.query.version ? Number(req.query.version) : undefined;
+    	let mission = Mission.fromVersion(doc, version);
 
 		let assuming = req.query.assuming as string;
 		if (!['none', 'gold', 'platinumquest'].includes(assuming)) assuming = 'platinumquest'; // Default to PQ
@@ -240,32 +242,15 @@ export const initLevelApi = () => {
 		res.send(packInfos);
 	});
 
-	const upload = multer();
-
-	// Upload a level archive. This doesn't yet submit it, but causes the processing/verification step.
-	app.post('/api/level/upload', upload.any(), async (req, res) => {
-		let { doc } = await authorize(req);
-		if (!doc) {
-			res.status(401).send("401\nInvalid token.");
-			return;
-		}
-
-		if (isSuspended(doc)) {
-			res.status(403).send("403\nAccount is suspended.");
-			return;
-		}
-
+	const processMissionArchive = async (req: express.Request, updateId?: number) => {
 		/** A list of problems with the upload, will be populated later. */
 		let problems: string[] = [];
 		/** A list of warnings regarding the upload. Warnings won't prevent submission. */
 		let warnings: string[] = [];
 		let zip: jszip;
-		let upload: MissionUpload;
 
-		if (req.headers['content-type'].startsWith('multipart/form-data')) {
+		if (req.headers['content-type']?.startsWith('multipart/form-data')) {
 			zip = new jszip();
-
-			// Simply create a zip from the uploaded files
 			for (let file of req.files as Express.Multer.File[]) {
 				zip.file(file.originalname, file.buffer);
 			}
@@ -277,52 +262,76 @@ export const initLevelApi = () => {
 			}
 		}
 
-		if (zip) {
-			try {
-				// Start processing the uploaded archive
-				upload = new MissionUpload(zip);
-				await upload.process();
+		if (!zip) return { upload: null, problems, warnings };
 
-				problems.push(...upload.problems);
-				warnings.push(...upload.warnings);
-			} catch (e) {
-				problems.push("An error occurred during processing.");
-
-				console.error("Upload processing error:");
-				console.error(e);
-			}
+		const upload = new MissionUpload(zip, updateId);
+		try {
+			await upload.process();
+			problems.push(...upload.problems);
+			warnings.push(...upload.warnings);
+		} catch (e) {
+			problems.push("An error occurred during processing.");
+			console.error("Upload processing error:", e);
 		}
 
-		if (problems.length > 0) {
-			res.status(400).send({
-				status: 'error',
-				problems: problems
-			});
-		} else {
-			// Because uploading is not the same as submitting, we simply remember the mission upload in memory for now. Upon submission, we'll actually write it to disk.
-			ongoingUploads.set(upload.id, upload);
+		return { upload, problems, warnings };
+	};
 
-			// Also send all of the uploader's packs
-			let packDocs = await db.packs.find({ createdBy: doc._id }) as PackDoc[];
-			packDocs.sort((a, b) => b.createdAt - a.createdAt); // Show newest ones first
-			let packs: PackInfo[] = [];
+	const authorizeUploader = async (req: express.Request, res: express.Response, existingLevelId?: number) => {
+        let { doc } = await authorize(req);
+        if (!doc) {
+            res.status(401).send("401\nInvalid token.");
+            return null;
+        }
+        if (isSuspended(doc)) {
+            res.status(403).send("403\nAccount is suspended.");
+            return null;
+        }
 
-			for (let doc of packDocs) {
-				packs.push(await getPackInfo(doc));
-			}
+        // If updating, verify ownership
+        if (existingLevelId !== undefined) {
+            let missionDoc = await db.missions.findOne({ _id: existingLevelId }) as MissionDoc;
+            if (!missionDoc) {
+                res.status(404).send("404\nLevel not found.");
+                return null;
+            }
+            if (missionDoc.addedBy !== doc._id && !doc.moderator) {
+                res.status(403).send("403\nUnauthorized to update this level.");
+                return null;
+            }
+        }
 
-			res.send({
-				status: 'success',
-				uploadId: upload.id,
-				missions: upload.groups.map(x => ({
-					misFilePath: x.misFilePath,
-					name: x.missionInfo.name
-				})),
-				packs: packs,
-				warnings: warnings
-			});
-		}
-	});
+        return doc;
+    };
+
+	const upload = multer();
+
+	// Upload a level archive. This doesn't yet submit it, but causes the processing/verification step.
+	app.post('/api/level/upload', upload.any(), async (req, res) => {
+        const doc = await authorizeUploader(req, res);
+        if (!doc) return;
+
+        const { upload, problems } = await processMissionArchive(req);
+
+        if (problems.length > 0) {
+            return res.status(400).send({ status: 'error', problems });
+        }
+
+        ongoingUploads.set(upload.id, upload);
+        
+        // Fetch user's packs
+        let packDocs = await db.packs.find({ createdBy: doc._id }) as PackDoc[];
+        packDocs.sort((a, b) => b.createdAt - a.createdAt);
+        let packs = await Promise.all(packDocs.map(p => getPackInfo(p)));
+
+        res.send({
+            status: 'success',
+            uploadId: upload.id,
+            missions: upload.groups.map(x => ({ misFilePath: x.misFilePath, name: x.missionInfo.name })),
+            packs,
+            warnings: [...upload.warnings]
+        });
+    });
 
 	// Submit a previously uploaded mission
 	app.post('/api/level/submit', async (req, res) => {
@@ -357,6 +366,48 @@ export const initLevelApi = () => {
 			newPackId
 		});
 	});
+
+	// Upload the level for updating purposes
+	app.post('/api/level/:levelId/update-upload', upload.any(), async (req, res) => {
+        const levelId = await verifyLevelId(req, res);
+        if (levelId === null) return;
+
+        const doc = await authorizeUploader(req, res, levelId);
+        if (!doc) return;
+
+        const { upload, problems, warnings } = await processMissionArchive(req, levelId);
+
+        if (problems.length > 0) {
+            return res.status(400).send({ status: 'error', problems });
+        }
+
+        ongoingUploads.set(upload.id, upload);
+        res.send({
+            status: 'success',
+            uploadId: upload.id,
+            missions: upload.groups.map(x => ({ misFilePath: x.misFilePath, name: x.missionInfo.name })),
+            warnings: [...warnings]
+        });
+    });
+
+	// Submit a previously uploaded update
+    app.post('/api/level/:levelId/update-submit', async (req, res) => {
+        const levelId = await verifyLevelId(req, res);
+        if (levelId === null) return;
+
+        const doc = await authorizeUploader(req, res, levelId);
+        if (!doc) return;
+
+        const upload = ongoingUploads.get(req.body.uploadId);
+        if (!upload) return res.status(400).send("Invalid or expired upload ID.");
+
+        const { docs } = await upload.submit(doc, {
+            ...req.body,
+            existingLevelId: levelId
+        });
+
+        res.send({ status: 'success', version: docs[0].currentVersion, levelIds: [levelId] });
+    });
 
 	// Meaning upload (noun) image. Is used to get an image preview of a level currently pending submission but not yet submitted.
 	app.get('/api/level/upload-image', async (req, res) => {
@@ -663,7 +714,30 @@ export const deleteSingleLevel = async (levelId: number) => {
 	// Delete all comments for this level
 	await db.comments.remove({ forType: 'level', for: levelId }, { multi: true });
 
-	// Delete the level's folder if there are no other levels that reside in it
-	let canDeleteDirectory = !(await db.missions.findOne({ baseDirectory: missionDoc.baseDirectory }));
-	if (canDeleteDirectory) await fs.remove(missionDoc.baseDirectory);
+	// Collect all directories to potentially delete
+	let directoriesToCheck = new Set<string>();
+
+	// Current version directory
+	if (missionDoc.baseDirectory) {
+		directoriesToCheck.add(missionDoc.baseDirectory);
+	}
+
+	// Past versions directories
+	if (missionDoc.pastVersions) {
+		for (let version of missionDoc.pastVersions) {
+			directoriesToCheck.add(version.baseDirectory);
+		}
+	}
+
+	// Check each directory before deleting
+	for (let dir of directoriesToCheck) {
+		// Check if any OTHER mission still uses this directory
+		let stillUsed = await db.missions.findOne({
+			$or: [ { baseDirectory: dir }, { "pastVersions.baseDirectory": dir } ]
+		});
+
+		if (!stillUsed) {
+			await fs.remove(dir);
+		}
+	}
 };

--- a/server/ts/mission.ts
+++ b/server/ts/mission.ts
@@ -7,7 +7,7 @@ import { Util } from './util';
 import { DtsParser } from './io/dts_parser';
 import { Config } from './config';
 import { config, datablocksMBG, datablocksMBW, db, keyValue, structureMBGSet, structurePQSet } from './globals';
-import { Modification, GameType, LevelInfo, ExtendedLevelInfo, PackInfo } from '../../shared/types';
+import { Modification, GameType, LevelInfo, ExtendedLevelInfo, PackInfo, CuratorVoteInfo } from '../../shared/types';
 import { AccountDoc, getProfileInfo } from './account';
 import { getPackInfo, PackDoc } from './pack'
 import { getCommentInfosForLevel } from './comment';
@@ -45,7 +45,24 @@ export interface MissionDoc {
 	curatorVotes: Record<number, boolean>,
 	editedAt: number,
 	hasCustomCode: boolean,
-	datablockCompatibility: 'mbg' | 'mbw' | 'pq'
+	datablockCompatibility: 'mbg' | 'mbw' | 'pq',
+	currentVersion?: number,
+	currentVersionChangelog?: string,
+	pastVersions?: MissionVersion[],
+}
+
+/** State of a level before it was updated */
+export interface MissionVersion {
+    versionNumber: number;
+	versionChangelog: string,
+    versionAddedAt: number;
+    baseDirectory: string;
+    relativePath: string;
+    misHash: string;
+    astHash: string;
+    dependencies: string[];
+    fileSizes: number[];
+    info: MissionElementScriptObject;
 }
 
 /** Represents a mission. Is responsible for constructing the asset dependency tree, as well as other smaller tasks. */
@@ -79,6 +96,9 @@ export class Mission {
 	editedAt: number = null;
 	hasCustomCode: boolean = false;
 	datablockCompatibility: 'mbg' | 'mbw' | 'pq';
+	currentVersion?: number;
+	currentVersionChangelog?: string;
+	pastVersions?: MissionVersion[];
 
 	constructor(baseDirectory: string, relativePath: string, id?: number) {
 		this.baseDirectory = baseDirectory;
@@ -116,9 +136,42 @@ export class Mission {
 		mission.editedAt = doc.editedAt ?? null;
 		mission.hasCustomCode = doc.hasCustomCode ?? false;
 		mission.datablockCompatibility = doc.datablockCompatibility ?? 'pq';
+		mission.currentVersion = doc.currentVersion ?? 1;
+		mission.pastVersions = doc.pastVersions ?? [];
+		mission.currentVersionChangelog = doc.currentVersionChangelog ?? '';
 
 		return mission;
 	}
+
+	static fromVersion(doc: MissionDoc, versionNumber?: number) {
+        // Initialize with the latest version's data and all global level metadata
+        let mission = Mission.fromDoc(doc);
+
+        // If no version or the latest version is requested, we are done
+		const currentVersion = doc.currentVersion || 1;
+        if (versionNumber === undefined || versionNumber === currentVersion) {
+            return mission;
+        }
+
+        // Find the snapshot
+        const v = doc.pastVersions.find(v => v.versionNumber === versionNumber);
+        if (!v) return null;
+
+        // Overwrite the fields that vary between versions
+        mission.currentVersion = v.versionNumber;
+        mission.baseDirectory = v.baseDirectory;
+        mission.relativePath = v.relativePath;
+        mission.misHash = v.misHash;
+        mission.astHash = v.astHash;
+        mission.dependencies = new Set(v.dependencies);
+        mission.fileSizes = v.fileSizes;
+        mission.info = v.info;
+        mission.currentVersionChangelog = v.versionChangelog;
+
+        mission.classify(); 
+
+        return mission;
+    }
 
 	/** Fill the mission with data. */
 	async hydrate() {
@@ -508,7 +561,8 @@ export class Mission {
 			hasCustomCode: this.hasCustomCode,
 			datablockCompatibility: this.datablockCompatibility,
 
-			curationScore: this.calculateCurationScore()
+			curationScore: this.calculateCurationScore(),
+			currentVersion: this.currentVersion,
 		};
 	}
 
@@ -536,6 +590,18 @@ export class Mission {
 			name: query.name
 		}));
 
+		let curatorVoteDetails: CuratorVoteInfo[] = [];
+		if (requesterDoc?.curator && this.curatorVotes) {
+			const curatorIds = Object.keys(this.curatorVotes).map(Number);
+			const accounts = await db.accounts.find({ _id: { $in: curatorIds } }) as AccountDoc[];
+			
+			// Resolve accounts to ProfileInfo objects
+			curatorVoteDetails = await Promise.all(accounts.map(async acc => ({
+				profile: await getProfileInfo(acc),
+				vote: this.curatorVotes[acc._id]
+			})));
+		}
+
 		let extended: ExtendedLevelInfo = {
 			...levelInfo,
 			addedBy: accountDoc && await getProfileInfo(accountDoc),
@@ -550,8 +616,14 @@ export class Mission {
 			dependencies: this.getFilteredDependencies('none', false),
 			playInfo,
 			leaderboardInfo: lbQueryInfo,
-			curatorVotes: requesterDoc?.curator ? this.curatorVotes : {},
-			yourVote: requesterDoc?.curator ? this.curatorVotes[requesterDoc._id] : null
+			curatorVotes: curatorVoteDetails,
+			yourVote: requesterDoc?.curator ? this.curatorVotes[requesterDoc._id] : null,
+			currentVersionChangelog: this.currentVersionChangelog,
+			pastVersions: this.pastVersions.map(v => ({
+				versionNumber: v.versionNumber,
+				versionAddedAt: v.versionAddedAt,
+				changelog: v.versionChangelog
+			}))
 		};
 		
 		return extended;

--- a/server/ts/mission_upload.ts
+++ b/server/ts/mission_upload.ts
@@ -337,7 +337,7 @@ export class MissionUpload {
 					return this.registerDependency(group, dependency.replace('interiors/', 'interiors_mbg/'), matchType, requiredBy, permittedExtensions, false, dependency);
 				} else {
 					// We definitely couldn't locate a file, add a problem
-					//this.problems.add(`Missing dependency: ${originalDependency ?? dependency} is required by ${requiredBy} but couldn't be found.`);
+					this.problems.add(`Missing dependency: ${originalDependency ?? dependency} is required by ${requiredBy} but couldn't be found.`);
 				}
 			}
 

--- a/server/ts/mission_upload.ts
+++ b/server/ts/mission_upload.ts
@@ -5,7 +5,7 @@ import * as crypto from 'crypto';
 import { MisFile, MisParser, MissionElementScriptObject, MissionElementSimGroup, MissionElementType } from './io/mis_parser';
 import { Config } from './config';
 import hxDif from '../lib/hxDif';
-import { IGNORE_MATERIALS, IMAGE_EXTENSIONS, Mission, MissionDoc } from './mission';
+import { IGNORE_MATERIALS, IMAGE_EXTENSIONS, Mission, MissionDoc, MissionVersion } from './mission';
 import { Util } from './util';
 import { DtsFile, DtsParser } from './io/dts_parser';
 import { db, keyValue } from './globals';
@@ -50,9 +50,12 @@ export class MissionUpload {
 	/** Stores a list of warnings regarding mission upload, which are things to pay attention to but not things that will prevent submission. */
 	warnings = new Set<string>();
 	groups: MissionGroup[] = [];
+	/** Optionally specify if we are updating a level */
+	updateId?: number
 
-	constructor(zip: jszip) {
+	constructor(zip: jszip, updateId?: number) {
 		this.zip = zip;
+		this.updateId = updateId;
 	}
 
 	/** Processes the uploaded missions, building the dependency tree while finding any problems present.
@@ -141,7 +144,7 @@ export class MissionUpload {
 
 		// Check if this .mis file is already present in the database and if so, abort
 		let misHash = crypto.createHash('sha256').update(text).digest('base64');
-		let existing = await db.missions.findOne({ misHash: misHash });
+		let existing = await db.missions.findOne({ misHash: misHash, _id: { $ne: this.updateId } });
 		if (existing) {
 			this.problems.add(`Duplicate: Mission ${group.misFilePath} has already been uploaded.`);
 			return false;
@@ -149,7 +152,7 @@ export class MissionUpload {
 	
 		// Hash the AST for more rigorous duplicate detection
 		let astHash = await MissionHasher.hashMission(null, text);
-		let existingAst = await db.missions.findOne({ astHash: astHash });
+		let existingAst = await db.missions.findOne({ astHash: astHash, _id: { $ne: this.updateId } });
 		if (existingAst) {
 			this.problems.add(`Duplicate: Mission ${group.misFilePath} has already been uploaded.`);
 			return false;
@@ -334,7 +337,7 @@ export class MissionUpload {
 					return this.registerDependency(group, dependency.replace('interiors/', 'interiors_mbg/'), matchType, requiredBy, permittedExtensions, false, dependency);
 				} else {
 					// We definitely couldn't locate a file, add a problem
-					this.problems.add(`Missing dependency: ${originalDependency ?? dependency} is required by ${requiredBy} but couldn't be found.`);
+					//this.problems.add(`Missing dependency: ${originalDependency ?? dependency} is required by ${requiredBy} but couldn't be found.`);
 				}
 			}
 
@@ -504,12 +507,35 @@ export class MissionUpload {
 	async submit(submitter: AccountDoc, requestBody: {
 		remarks: string[],
 		addToPacks: number[],
+		existingLevelId? : number,
 		newPack?: {
 			name: string,
 			description: string
 		}
 	}) {
 		if (this.hasExpired()) throw new Error("Expired.");
+
+		const writeGroupToDisk = async (group: MissionGroup, levelId: number, version?: number) => {
+			let folderName = levelId.toString() + (version !== undefined ? `-v${version}` : "");
+			const directoryPath = path.join(__dirname, 'storage', 'levels', folderName);
+
+			await fs.ensureDir(directoryPath);
+
+			// Write all normalized files to the target directory
+			for (let [relativePath, file] of group.normalizedDirectory) {
+				const buffer = await file.async('nodebuffer');
+				const fullPath = path.join(directoryPath, relativePath);
+				await fs.ensureFile(fullPath);
+				await fs.writeFile(fullPath, buffer);
+			}
+
+			// Identify the .mis file and hydrate the mission object
+			const relativePath = [...group.normalizedDirectory.keys()].find(x => x.endsWith('.mis'));
+			const mission = new Mission(directoryPath, relativePath, levelId);
+			await mission.hydrate();
+
+			return mission;
+		}
 
 		let packDocs: PackDoc[] = [];
 		let newPackId: number = null;
@@ -531,43 +557,74 @@ export class MissionUpload {
 			newPackId = newPackDoc._id;
 		}
 
-		let docs: MissionDoc[] = [];
-		for (let [i, group] of this.groups.entries()) {
-			let levelId = keyValue.get('levelId');
-			keyValue.set('levelId', levelId + 1);
+		let finalDocs: MissionDoc[] = [];
 
-			let directoryPath = path.join(__dirname, 'storage', 'levels', levelId.toString());
-			await fs.ensureDir(directoryPath); // Create the new directory
+		if (requestBody.existingLevelId !== undefined) {
+            // --- UPDATE PATH ---
+            let missionDoc = await db.missions.findOne({ _id: requestBody.existingLevelId }) as MissionDoc;
+            if (!missionDoc) throw new Error("Level not found.");
 
-			// Write everything to disk
-			for (let [relativePath, file] of group.normalizedDirectory) {
-				let buffer = await file.async('nodebuffer');
-				let fullPath = path.join(directoryPath, relativePath);
-				await fs.ensureFile(fullPath);
-				await fs.writeFile(fullPath, buffer);
-			}
+            // Snapshot current state before overwriting
+            const snapshot: MissionVersion = {
+                versionNumber: missionDoc.currentVersion || 1,
+				versionChangelog: missionDoc.currentVersionChangelog,
+                versionAddedAt: missionDoc.editedAt || missionDoc.addedAt,
+                baseDirectory: missionDoc.baseDirectory,
+                relativePath: missionDoc.relativePath,
+                misHash: missionDoc.misHash,
+                astHash: missionDoc.astHash,
+                dependencies: missionDoc.dependencies,
+                fileSizes: missionDoc.fileSizes,
+                info: missionDoc.info
+            };
 
-			// Create a mission at the newly created directory and hydrate it like we would with any other mission
-			let relativePath = [...group.normalizedDirectory.keys()].find(x => x.endsWith('.mis'));
-			let mission = new Mission(directoryPath, relativePath, levelId);
-			await mission.hydrate();
+            missionDoc.pastVersions = missionDoc.pastVersions ?? [];
+            missionDoc.pastVersions.push(snapshot);
+			missionDoc.currentVersionChangelog = requestBody.remarks[0];
+            missionDoc.currentVersion = snapshot.versionNumber + 1;
 
-			// Add the mission to the database
-			let doc = mission.createDoc();
-			doc.addedBy = submitter._id;
-			doc.remarks = requestBody.remarks[i] ?? '';
+            // Use first group in upload for writing
+            const mission = await writeGroupToDisk(this.groups[0], missionDoc._id, missionDoc.currentVersion);
 
-			docs.push(doc);
-		}
+            // Update existing doc
+            const newDocData = mission.createDoc();
+            Object.assign(missionDoc, {
+                baseDirectory: newDocData.baseDirectory,
+                relativePath: newDocData.relativePath,
+                dependencies: newDocData.dependencies,
+                fileSizes: newDocData.fileSizes,
+                info: newDocData.info,
+                misHash: newDocData.misHash,
+                astHash: newDocData.astHash,
+                editedAt: Date.now()
+            });
 
-		await db.missions.insert(docs);
+            await db.missions.update({ _id: missionDoc._id }, missionDoc);
+            finalDocs = [missionDoc];
+
+        } else {
+            // --- UPLOAD PATH ---
+            for (let [i, group] of this.groups.entries()) {
+                const levelId = keyValue.get('levelId');
+                keyValue.set('levelId', levelId + 1);
+
+                const mission = await writeGroupToDisk(group, levelId);
+
+                const doc = mission.createDoc();
+                doc.addedBy = submitter._id;
+                doc.remarks = requestBody.remarks[i] ?? '';
+
+                await db.missions.insert(doc);
+                finalDocs.push(doc);
+            }
+        }
 
 		// Now, let's do all the pack updating:
 
 		let promises: Promise<any>[] = [];
 
 		for (let packDoc of packDocs) {
-			packDoc.levels.push(...docs.map(x => x._id));
+			packDoc.levels.push(...finalDocs.map(x => x._id));
 			promises.push(createPackThumbnail(packDoc));
 
 			await db.packs.update({ _id: packDoc._id }, packDoc, { upsert: true });
@@ -578,7 +635,7 @@ export class MissionUpload {
 		ongoingUploads.delete(this.id);
 
 		return {
-			docs,
+			docs: finalDocs,
 			newPackId
 		};
 	}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -65,6 +65,20 @@ export interface LevelInfo {
 	datablockCompatibility: Mission['datablockCompatibility'],
 
 	curationScore: number,
+	currentVersion: number;
+}
+
+/** Contains minimal version info to display on the Level page. */
+export interface VersionInfo {
+	versionNumber: number;
+	versionAddedAt: number;
+	changelog: string;
+}
+
+/** Contains voter info for display in a modal. */
+export interface CuratorVoteInfo {
+    profile: ProfileInfo,
+    vote: boolean
 }
 
 /** Contains metadata about a level, as well as additional data to display on the Level page. */
@@ -80,8 +94,10 @@ export interface ExtendedLevelInfo extends LevelInfo {
 	dependencies: string[],
 	playInfo: GameDefinition[],
 	leaderboardInfo: ReducedLeaderboardDefinition[],
-	curatorVotes: Record<number, boolean>,
+	curatorVotes: CuratorVoteInfo[],
 	yourVote: boolean,
+	currentVersionChangelog: string,
+	pastVersions: VersionInfo[];
 }
 
 /** Contains metadata about a profile. */

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -116,6 +116,7 @@ export interface ProfileInfo {
 export interface ExtendedProfileInfo extends ProfileInfo {
 	bio: string,
 	uploadedLevels: LevelInfo[],
+	favoriteLevels: LevelInfo[],
 	createdPacks: PackInfo[]
 }
 

--- a/version_history.md
+++ b/version_history.md
@@ -1,5 +1,9 @@
 ### Version history
 
+## 1.12.0
+- Added level update feature
+- Added "favorite levels" section
+
 ## 1.11.0
 - Added Curator role and voting system
 - Fixed .zip downloads failing for levels with non-Latin-1 filenames


### PR DESCRIPTION
Features:
- Implemented "Update level" button on the level page, which brings you to the level upload page.
- Updated the level page to display all previous versions and their changelog.
- Added a modal on the level page for curators to view which accounts voted what.

Internal changes:
- Updated the level upload page to do level updating (write changelog, don't add to pack) if an update id is provided
- Added "pastVersions" property to missions to store info about a previous version
- Added "currentVersion" and "currentVersionChangelog" property to missions
- Updated MissionUpload::submit to accept an existingLevelId. If provided, a previousVersion is created and the updated level is stored in a folder named: {levelId}-v{version} in the same directory.
- Updated deleteSingleLevel to delete all pastVersion mission directories.
- Updated /api/level/:levelId/zip and /api/level/:levelId/mbpak to accept a level version number.
- Updated DownloadButton to use a "version" field
- Added optional "updateId" to MissionUpload constructor to prevent duplicate mis error (in case the user didn't change the .mis when updating)
- Changed ExtendedLevelInfo.curatorVotes to return ProfileInfo instead of user id.