### PR TITLE
Granular control over datablock compatibilities for games and leaderboards.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -634,8 +634,9 @@ Contains the definition of a game the level can be played on
 {
 	id: string,
 	name: string,
-	datablockCompatibility: 'mbg' | 'mbw' | 'pq', // The minimum datablock compatibility required by the level to be playable in the game
+	datablockCompatibilities: ['mbg' | 'mbw' | 'pq'][], // The list of datablock compatibilities this game can play
 	playUrl: string, // The direct link to play the level in the defined game
+	customCodeAllowed: boolean, // Whether this game allows playing levels that utilise custom code.
 }
 ```
 
@@ -645,8 +646,9 @@ Contains the definition of a leaderboard source for levels.
 {
 	id: string,
 	name: string,
-	datablockCompatibility: 'mbg' | 'mbw' | 'pq', // The minimum datablock compatibility required by the level to be playable in the game
+	datablockCompatibility: ['mbg' | 'mbw' | 'pq'][], // The list of datablock compatibilities this game can play
 	queryUrl: string, // The leaderboard endpoint that can be used to query the leaderboard for the level
+	customCodeAllowed: boolean, // Whether this game allows playing levels that utilise custom code.
 }
 ```
 

--- a/server/ts/api/api_level.ts
+++ b/server/ts/api/api_level.ts
@@ -581,7 +581,7 @@ export const initLevelApi = () => {
 		let mission = Mission.fromDoc(doc);
 
 		let leaderboardId = req.params.leaderboardId;
-		let lbQueryInfo = Util.chooseDataByDatablockCompatibility(config.leaderboardSources, mission.datablockCompatibility);
+		let lbQueryInfo = config.leaderboardSources.filter(x => x.datablockCompatibilites.includes(mission.datablockCompatibility) && ((mission.hasCustomCode && x.customCodeAllowed) || !mission.hasCustomCode));
 		let query = lbQueryInfo.find(x => x.id === leaderboardId);
 		if (query === undefined) {
 			res.status(400).send("400\nLevel does not contain the specified leaderboard.");

--- a/server/ts/mission.ts
+++ b/server/ts/mission.ts
@@ -526,12 +526,12 @@ export class Mission {
 
 		let lovedByYou = this.lovedBy.includes(requesterId);
 
-		let playInfo = Util.chooseDataByDatablockCompatibility(config.games, this.datablockCompatibility).map(game => ({
+		let playInfo = config.games.filter(x => x.datablockCompatibilites.includes(this.datablockCompatibility) && ((this.hasCustomCode && x.customCodeAllowed) || !this.hasCustomCode)).map(game => ({
 			...game,
 			playUrl: game.playUrl.replace('{id}', this.id.toString()),
 		}));
 
-		let lbQueryInfo = Util.chooseDataByDatablockCompatibility(config.leaderboardSources, this.datablockCompatibility).map(query => ({
+		let lbQueryInfo = config.leaderboardSources.filter(x => x.datablockCompatibilites.includes(this.datablockCompatibility) && ((this.hasCustomCode && x.customCodeAllowed) || !this.hasCustomCode)).map(query => ({
 			id: query.id,
 			name: query.name
 		}));

--- a/server/ts/util.ts
+++ b/server/ts/util.ts
@@ -319,22 +319,6 @@ export class Util {
 			}
 		});
 	}
-
-	/** Choose data playable by the given datablockCompatibility i.e filters the data whose datablocks are compatible with that of datablockCompatibility */
-	static chooseDataByDatablockCompatibility<T extends DataDefinitionBase>(games: T[], datablockCompatibility: Mission["datablockCompatibility"]) {
-		// PQ levels can only run on PQ
-		// MBW levels can run on both PQ and MBW
-		// MBG levels can run on all
-		let selected: T[] = [];
-		let compatibilityLevel = { mbg: 0, mbw: 1, pq: 2 }[datablockCompatibility];
-		for (const game of games) {
-			let gameCompatibilityLevel = { mbg: 0, mbw: 1, pq: 2 }[game.datablockCompatibility];
-			if (gameCompatibilityLevel >= compatibilityLevel) {
-				selected.push(game);
-			}
-		}
-		return selected;
-	}
 }
 
 /** A simple persistent key/value store */

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -16,7 +16,8 @@ export enum Modification {
 export type DataDefinitionBase = {
 	id: string,
 	name: string,
-	datablockCompatibility: Mission['datablockCompatibility'],
+	datablockCompatibilites: Mission['datablockCompatibility'][],
+	customCodeAllowed: boolean
 };
 
 export type GameDefinition = DataDefinitionBase & { playUrl: string };

--- a/version_history.md
+++ b/version_history.md
@@ -1,5 +1,8 @@
 ### Version history
 
+## 1.11.1
+- Added support for filtering games and leaderboards based on exact datablock compatibility values as well as custom code.
+
 ## 1.11.0
 - Added Curator role and voting system
 - Fixed .zip downloads failing for levels with non-Latin-1 filenames


### PR DESCRIPTION
- Lets you specify what all datablock compatibilities each games support
- Also lets you specify whether the game supports custom code or not.
All of this is for showing the play button/leaderboards.